### PR TITLE
Merge JSch auth classes and bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     </parent>
 
     <artifactId>jsch</artifactId>
-    <version>0.1.52.0-SNAPSHOT</version>
+    <version>0.1.54.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Jenkins JSch dependency plugin</name>
@@ -46,8 +46,8 @@
         <maven-release-plugin.version>2.5.1</maven-release-plugin.version>
 
         <deps.apache-sshd.version>0.12.0</deps.apache-sshd.version>
-        <deps.jsch.version>0.1.52</deps.jsch.version>
-        <deps.ssh-credentials-plugin.version>1.13-SNAPSHOT</deps.ssh-credentials-plugin.version>
+        <deps.jsch.version>0.1.54</deps.jsch.version>
+        <deps.ssh-credentials-plugin.version>1.12</deps.ssh-credentials-plugin.version>
     </properties>
 
   <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->

--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,16 @@
         <version>1.477</version>
     </parent>
 
-    <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>jsch</artifactId>
-    <version>0.1.43-SNAPSHOT</version>
+    <version>0.1.52.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Jenkins JSch dependency plugin</name>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/JSch+plugin</url>
-    <description>Jenkins plugin that brings the JSch library as a plugin dependency, does not have any functionality by itself.</description>
+    <description>
+        Jenkins plugin that brings the JSch library as a plugin dependency, and provides
+        an SSHAuthenticatorFactory for using JSch with the ssh-credentials plugin.
+    </description>
 
     <scm>
         <connection>scm:git:git@github.com:jenkinsci/jsch-plugin.git</connection>
@@ -34,10 +36,18 @@
             <id>zregvart</id>
             <name>Zoran Regvart</name>
         </developer>
+        <developer>
+            <id>bpedman</id>
+            <name>Brandon Pedersen</name>
+        </developer>
     </developers>
 
     <properties>
         <maven-release-plugin.version>2.5.1</maven-release-plugin.version>
+
+        <deps.apache-sshd.version>0.12.0</deps.apache-sshd.version>
+        <deps.jsch.version>0.1.52</deps.jsch.version>
+        <deps.ssh-credentials-plugin.version>1.13-SNAPSHOT</deps.ssh-credentials-plugin.version>
     </properties>
 
   <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
@@ -56,10 +66,26 @@
     </pluginRepositories>
 
     <dependencies>
+        <!-- plugin dependencies -->
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.42</version>
+            <version>${deps.jsch.version}</version>
+        </dependency>
+
+        <!-- jenkins dependencies -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>ssh-credentials</artifactId>
+            <version>${deps.ssh-credentials-plugin.version}</version>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.apache.sshd</groupId>
+            <artifactId>sshd-core</artifactId>
+            <version>${deps.apache-sshd.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/jenkinsci/plugins/jsch/JSchConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/jsch/JSchConnector.java
@@ -1,0 +1,54 @@
+package org.jenkinsci.plugins.jsch;
+
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticatorException;import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+
+/**
+ * @author stephenc
+ * @since 25/10/2012 15:14
+ */
+public class JSchConnector {
+    private final JSch jsch;
+    private final String host;
+    private final int port;
+    private Session session = null;
+    private final String username;
+
+    public JSchConnector(String username, String host, int port) {
+        this(new JSch(), username, host, port);
+    }
+
+    public JSchConnector(JSch jsch, String username, String host, int port) {
+        this.host = host;
+        this.jsch = jsch;
+        this.port = port;
+        this.username = username;
+    }
+
+    public JSch getJSch() {
+        return jsch;
+    }
+
+    public synchronized boolean hasSession() {
+        return session != null;
+    }
+
+    public synchronized Session getSession() {
+        if (!hasSession()) {
+            try {
+                session = jsch.getSession(username, host, port);
+            } catch (JSchException e) {
+                throw new SSHAuthenticatorException(e);
+            }
+        }
+        return session;
+    }
+
+    public synchronized void close() {
+        if (session != null) {
+            session.disconnect();
+            session = null;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/jsch/JSchConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/jsch/JSchConnector.java
@@ -6,7 +6,7 @@ import com.jcraft.jsch.Session;
 
 /**
  * @author stephenc
- * @since 25/10/2012 15:14
+ * @since 0.1.54.0
  */
 public class JSchConnector {
     private final JSch jsch;

--- a/src/main/java/org/jenkinsci/plugins/jsch/JSchSSHPasswordAuthenticator.java
+++ b/src/main/java/org/jenkinsci/plugins/jsch/JSchSSHPasswordAuthenticator.java
@@ -1,0 +1,143 @@
+package org.jenkinsci.plugins.jsch;
+
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator;
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticatorFactory;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Extension;
+
+import java.util.logging.Logger;
+
+/**
+ * @author stephenc
+ * @since 25/10/2012 13:57
+ */
+public class JSchSSHPasswordAuthenticator extends SSHAuthenticator<JSchConnector, StandardUsernamePasswordCredentials> {
+
+    /**
+     * Our logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(JSchSSHPasswordAuthenticator.class.getName());
+
+    protected JSchSSHPasswordAuthenticator(@NonNull JSchConnector connection,
+                                           @NonNull StandardUsernamePasswordCredentials user) {
+        this(connection, user, null);
+    }
+
+    protected JSchSSHPasswordAuthenticator(@NonNull JSchConnector connection,
+                                           @NonNull StandardUsernamePasswordCredentials user,
+                                           @CheckForNull String username) {
+        super(connection, user, username);
+    }
+
+    @NonNull
+    @Override
+    public Mode getAuthenticationMode() {
+        return Mode.BEFORE_CONNECT;
+    }
+
+    @Override
+    public boolean canAuthenticate() {
+        return !getConnection().hasSession()
+                || (getConnection().getSession().isConnected() && getConnection().getSession().getUserInfo() == null);
+    }
+
+    @Override
+    protected boolean doAuthenticate() {
+        final Session session = getConnection().getSession();
+        session.setUserInfo(new JSchUserInfo());
+        session.setPassword(getUser().getPassword().getPlainText());
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Extension(optional = true)
+    public static class Factory extends SSHAuthenticatorFactory {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        @SuppressWarnings("unchecked")
+        protected <C, U extends StandardUsernameCredentials> SSHAuthenticator<C, U> newInstance(@NonNull C session,
+                                                                                                @NonNull U user) {
+            return newInstance(session, user, null);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Nullable
+        @Override
+        @SuppressWarnings("unchecked")
+        protected <C, U extends StandardUsernameCredentials> SSHAuthenticator<C, U> newInstance(@NonNull C session,
+                                                                                                @NonNull U user,
+                                                                                                @CheckForNull String
+                                                                                                        username) {
+            if (supports(session.getClass(), user.getClass())) {
+                return (SSHAuthenticator<C, U>) new JSchSSHPasswordAuthenticator((JSchConnector) session,
+                        (StandardUsernamePasswordCredentials) user, username);
+            }
+            return null;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        protected <C, U extends StandardUsernameCredentials> boolean supports(@NonNull Class<C> connectionClass,
+                                                                              @NonNull Class<U> userClass) {
+            return JSchConnector.class.isAssignableFrom(connectionClass)
+                    && StandardUsernamePasswordCredentials.class.isAssignableFrom(userClass);
+        }
+
+        private static final long serialVersionUID = 1L;
+    }
+
+    private class JSchUserInfo implements UserInfo, UIKeyboardInteractive {
+
+        public String getPassphrase() {
+            return "";
+        }
+
+        public String getPassword() {
+            return getUser().getPassword().getPlainText();
+        }
+
+        public boolean promptPassword(String message) {
+            LOGGER.info(message);
+            return true;
+        }
+
+        public boolean promptPassphrase(String message) {
+            LOGGER.info(message);
+            return false;
+        }
+
+        public boolean promptYesNo(String message) {
+            LOGGER.info(message);
+            return false;
+        }
+
+        public void showMessage(String message) {
+            LOGGER.info(message);
+        }
+
+        public String[] promptKeyboardInteractive(String destination, String name, String instruction, String[] prompt,
+                                                  boolean[] echo) {
+            // most SSH servers just use keyboard interactive to prompt for the password
+            // match "assword" is safer than "password"... you don't *want* to know why!
+            return prompt != null && prompt.length > 0 && prompt[0].toLowerCase().contains("assword")
+                    ? new String[]{getUser().getPassword().getPlainText()}
+                    : new String[0];
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/jsch/JSchSSHPasswordAuthenticator.java
+++ b/src/main/java/org/jenkinsci/plugins/jsch/JSchSSHPasswordAuthenticator.java
@@ -16,7 +16,7 @@ import java.util.logging.Logger;
 
 /**
  * @author stephenc
- * @since 25/10/2012 13:57
+ * @since 0.1.54.0
  */
 public class JSchSSHPasswordAuthenticator extends SSHAuthenticator<JSchConnector, StandardUsernamePasswordCredentials> {
 

--- a/src/main/java/org/jenkinsci/plugins/jsch/JSchSSHPublicKeyAuthenticator.java
+++ b/src/main/java/org/jenkinsci/plugins/jsch/JSchSSHPublicKeyAuthenticator.java
@@ -1,0 +1,133 @@
+package org.jenkinsci.plugins.jsch;
+
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator;
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticatorException;
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticatorFactory;
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.jcraft.jsch.JSchException;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Extension;
+import hudson.util.Secret;
+
+import java.io.UnsupportedEncodingException;
+import java.util.logging.Logger;
+
+/**
+ * @author stephenc
+ * @since 25/10/2012 14:49
+ */
+public class JSchSSHPublicKeyAuthenticator extends SSHAuthenticator<JSchConnector, SSHUserPrivateKey> {
+
+    /**
+     * Our logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(JSchSSHPublicKeyAuthenticator.class.getName());
+
+    /**
+     * Constructor.
+     *
+     * @param connector the connection we will be authenticating.
+     */
+    public JSchSSHPublicKeyAuthenticator(JSchConnector connector, SSHUserPrivateKey user) {
+        this(connector, user, null);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param connector the connection we will be authenticating.
+     * @since 1.4
+     */
+    public JSchSSHPublicKeyAuthenticator(@NonNull JSchConnector connector, @NonNull SSHUserPrivateKey user,
+                                         @CheckForNull String username) {
+        super(connector, user, username);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean canAuthenticate() {
+        return !getConnection().hasSession()
+                || (getConnection().getSession().isConnected() && getConnection().getSession().getUserInfo() == null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected boolean doAuthenticate() {
+        try {
+            final SSHUserPrivateKey user = getUser();
+            final Secret userPassphrase = user.getPassphrase();
+            final String passphrase = userPassphrase == null ? null : userPassphrase.getPlainText();
+            byte[] passphraseBytes = passphrase == null ? null : passphrase.getBytes("UTF-8");
+            for (String privateKey : getPrivateKeys(user)) {
+                getConnection().getJSch().addIdentity(getUsername(), privateKey.getBytes("UTF-8"), null,
+                        passphraseBytes);
+            }
+
+            return true;
+        } catch (JSchException e) {
+            e.printStackTrace(getListener().error("Failed to authenticate with public key"));
+            return false;
+        } catch (UnsupportedEncodingException e) {
+            throw new SSHAuthenticatorException(e);
+        }
+    }
+
+    @NonNull
+    @Override
+    public Mode getAuthenticationMode() {
+        return Mode.BEFORE_CONNECT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Extension
+    public static class Factory extends SSHAuthenticatorFactory {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        @SuppressWarnings("unchecked")
+        protected <C, U extends StandardUsernameCredentials> SSHAuthenticator<C, U> newInstance(@NonNull C session,
+                                                                                                @NonNull U user) {
+            return newInstance(session, user, null);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Nullable
+        @Override
+        @SuppressWarnings("unchecked")
+        protected <C, U extends StandardUsernameCredentials> SSHAuthenticator<C, U> newInstance(@NonNull C session,
+                                                                                                @NonNull U user,
+                                                                                                @CheckForNull String
+                                                                                                        username) {
+            if (supports(session.getClass(), user.getClass())) {
+                return (SSHAuthenticator<C, U>) new JSchSSHPublicKeyAuthenticator((JSchConnector) session,
+                        (SSHUserPrivateKey) user, username);
+            }
+            return null;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        protected <C, U extends StandardUsernameCredentials> boolean supports(@NonNull Class<C> connectionClass,
+                                                                              @NonNull Class<U> userClass) {
+            return JSchConnector.class.isAssignableFrom(connectionClass)
+                    && SSHUserPrivateKey.class.isAssignableFrom(userClass);
+        }
+
+        private static final long serialVersionUID = 1L;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/jsch/JSchSSHPublicKeyAuthenticator.java
+++ b/src/main/java/org/jenkinsci/plugins/jsch/JSchSSHPublicKeyAuthenticator.java
@@ -17,7 +17,7 @@ import java.util.logging.Logger;
 
 /**
  * @author stephenc
- * @since 25/10/2012 14:49
+ * @since 0.1.54.0
  */
 public class JSchSSHPublicKeyAuthenticator extends SSHAuthenticator<JSchConnector, SSHUserPrivateKey> {
 

--- a/src/test/java/org/jenkinsci/plugins/jsch/JSchSSHPasswordAuthenticatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/jsch/JSchSSHPasswordAuthenticatorTest.java
@@ -1,0 +1,189 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011-2012, CloudBees, Inc., Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.jsch;
+
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator;
+import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPassword;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.jcraft.jsch.HostKey;
+import com.jcraft.jsch.HostKeyRepository;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.UserInfo;
+import hudson.model.Items;
+import org.apache.sshd.SshServer;
+import org.apache.sshd.common.NamedFactory;
+import org.apache.sshd.server.PasswordAuthenticator;
+import org.apache.sshd.server.UserAuth;
+import org.apache.sshd.server.auth.UserAuthPassword;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.apache.sshd.server.session.ServerSession;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+public class JSchSSHPasswordAuthenticatorTest {
+
+    private JSchConnector connector;
+    private StandardUsernamePasswordCredentials user;
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @After
+    public void tearDown() throws Exception {
+        if (connector != null) {
+            connector.close();
+            connector = null;
+        }
+    }
+
+    // disabled as Apache MINA sshd does not provide easy mech for giving a Keyboard Interactive authenticator
+    // so this test relies on having a local sshd which is keyboard interactive only
+    public void dontTestKeyboardInteractive() throws Exception {
+
+        BasicSSHUserPassword user = new BasicSSHUserPassword(CredentialsScope.SYSTEM,
+                null, "....",  // <---- put your username here
+                "....",  // <---- put your password here
+                null);
+        JSch jsch = new JSch();
+        jsch.setHostKeyRepository(new BlindTrustHostKeyRepository());
+        connector = new JSchConnector(user.getUsername(), "localhost", 22);
+        JSchSSHPasswordAuthenticator instance = new JSchSSHPasswordAuthenticator (connector, user);
+        assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.BEFORE_CONNECT));
+        assertThat(instance.canAuthenticate(), is(true));
+        assertThat(instance.authenticate(), is(true));
+        assertThat(instance.isAuthenticated(), is(true));
+        assertThat(connector.getSession().isConnected(), is(false));
+        connector.getSession().setConfig("StrictHostKeyChecking", "no");
+        connector.getSession().connect((int) TimeUnit.SECONDS.toMillis(60));
+        assertThat(connector.getSession().isConnected(), is(true));
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        user =(StandardUsernamePasswordCredentials) Items.XSTREAM.fromXML(Items.XSTREAM.toXML(new BasicSSHUserPassword(CredentialsScope.SYSTEM, null, "foobar", "foomanchu", null)));
+    }
+
+    @Test
+    public void testPassword() throws Exception {
+        SshServer sshd = SshServer.setUpDefaultServer();
+        sshd.setPort(0);
+        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
+        sshd.setPasswordAuthenticator(new PasswordAuthenticator() {
+            public boolean authenticate(String username, String password, ServerSession session) {
+                return "foomanchu".equals(password);
+            }
+        });
+        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPassword.Factory()));
+        try {
+            sshd.start();
+            connector = new JSchConnector(user.getUsername(),"localhost", sshd.getPort());
+            JSchSSHPasswordAuthenticator instance = new JSchSSHPasswordAuthenticator(connector, user);
+            assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.BEFORE_CONNECT));
+            assertThat(instance.canAuthenticate(), is(true));
+            assertThat(instance.authenticate(), is(true));
+            assertThat(instance.isAuthenticated(), is(true));
+            assertThat(connector.getSession().isConnected(), is(false));
+            connector.getSession().setConfig("StrictHostKeyChecking", "no");
+            connector.getSession().connect((int) TimeUnit.SECONDS.toMillis(30));
+            assertThat(connector.getSession().isConnected(), is(true));
+        } finally {
+            try {
+                sshd.stop(true);
+            } catch (Throwable t) {
+                Logger.getLogger(getClass().getName()).log(Level.WARNING, "Problems shutting down ssh server", t);
+            }
+        }
+    }
+
+    @Test
+    public void testFactory() throws Exception {
+        SshServer sshd = SshServer.setUpDefaultServer();
+        sshd.setPort(0);
+        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
+        sshd.setPasswordAuthenticator(new PasswordAuthenticator() {
+            public boolean authenticate(String username, String password, ServerSession session) {
+                return "foomanchu".equals(password);
+            }
+        });
+        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPassword.Factory()));
+        try {
+            sshd.start();
+            connector = new JSchConnector(user.getUsername(),"localhost", sshd.getPort());
+            SSHAuthenticator instance = SSHAuthenticator.newInstance(connector, user);
+            assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.BEFORE_CONNECT));
+            assertThat(instance.canAuthenticate(), is(true));
+            assertThat(instance.authenticate(), is(true));
+            assertThat(instance.isAuthenticated(), is(true));
+            assertThat(connector.getSession().isConnected(), is(false));
+            connector.getSession().setConfig("StrictHostKeyChecking", "no");
+            connector.getSession().connect((int) TimeUnit.SECONDS.toMillis(30));
+            assertThat(connector.getSession().isConnected(), is(true));
+        } finally {
+            try {
+                sshd.stop(true);
+            } catch (Throwable t) {
+                Logger.getLogger(getClass().getName()).log(Level.WARNING, "Problems shutting down ssh server", t);
+            }
+        }
+    }
+
+    private static class BlindTrustHostKeyRepository implements HostKeyRepository {
+
+        public int check(String host, byte[] key) {
+            return OK;
+        }
+
+        public void add(HostKey hostkey, UserInfo ui) {
+        }
+
+        public void remove(String host, String type) {
+        }
+
+        public void remove(String host, String type, byte[] key) {
+        }
+
+        public String getKnownHostsRepositoryID() {
+            return null;
+        }
+
+        public HostKey[] getHostKey() {
+            return new HostKey[0];
+        }
+
+        public HostKey[] getHostKey(String host, String type) {
+            return new HostKey[0];
+        }
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/jsch/JSchSSHPublicKeyAuthenticatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/jsch/JSchSSHPublicKeyAuthenticatorTest.java
@@ -1,0 +1,202 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011-2012, CloudBees, Inc., Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.jsch;
+
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator;
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.CredentialsDescriptor;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.util.Secret;
+import org.apache.sshd.SshServer;
+import org.apache.sshd.common.NamedFactory;
+import org.apache.sshd.server.PublickeyAuthenticator;
+import org.apache.sshd.server.UserAuth;
+import org.apache.sshd.server.auth.UserAuthPublicKey;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.apache.sshd.server.session.ServerSession;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.security.PublicKey;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+public class JSchSSHPublicKeyAuthenticatorTest {
+
+    private JSchConnector connector;
+    private SSHUserPrivateKey user;
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @After
+    public void tearDown() throws Exception {
+        if (connector != null) {
+            connector.close();
+            connector = null;
+        }
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        user = new SSHUserPrivateKey() {
+
+            @NonNull
+            public String getUsername() {
+                return "foobar";
+            }
+
+            @NonNull
+            public String getDescription() {
+                return "";
+            }
+
+            @NonNull
+            public String getId() {
+                return "";
+            }
+
+            public CredentialsScope getScope() {
+                return CredentialsScope.SYSTEM;
+            }
+
+            @NonNull
+            public CredentialsDescriptor getDescriptor() {
+                return new CredentialsDescriptor() {
+                    @Override
+                    public String getDisplayName() {
+                        return "";
+                    }
+                };
+            }
+
+            @NonNull
+            public String getPrivateKey() {
+                // just want a valid key... I generated this and have thrown it away (other than here)
+                // do not use other than in this test
+                return "-----BEGIN RSA PRIVATE KEY-----\n"
+                        + "MIICWQIBAAKBgQDADDwooNPJNQB4N4bJPiBgq/rkWKMABApX0w4trSkkX5q+l+CL\n"
+                        + "CuddGGAsAu6XPari8v49ipbBmHqRLP9+X3ARGWKU2gDvGTBr99/ReUl2YgVjCwy+\n"
+                        + "KMrGCN7SNTgRo6StwVaPhh6pUpNTQciDe/kOwUnQFWSM6/lwkOD1Uod45wIBIwKB\n"
+                        + "gHi3O8HELVnmzRhdaqphkLHLL/0/B18Ye4epPBy1/JqFPLJQ1kjFBnUIAe/HVCSN\n"
+                        + "KZX30wIcmUZ9GdeYoJiTwsfTy9t2KwHjqrapTfiekVZAW+3iDBqRZMxQ5MoK7b6g\n"
+                        + "w5HrrtrtPfYuAsBnYjIS6qsKAVT3vdolJ5eai/RlPO4LAkEA76YuUozC/dW7Ox+R\n"
+                        + "1Njd6cWJsRVXGemkSYY/rSh0SbfHAebqL/bDg8xXim9UiuD9Hc6md3glHQj6iKvl\n"
+                        + "BxWq4QJBAM0moKiM16WFSFJP1wVDj0Bnx6DkJYSpf5u+C0ghBVoqIYKq6/P/gRE2\n"
+                        + "+ColsLu6AYftaEJVpAgxeTU/IsGoJMcCQHRmqMkCipiMYkFJ2R49cxnGWNJa0ojt\n"
+                        + "03QrQ3/9tNNZQ2dS5sbW8UAEKoURgNW9vMVVvpHMpE/uaw8u65W6ESsCQDTAyjn4\n"
+                        + "VLWIrDJsTTveLCaBFhNt3cMHA45ysnGiF1GzD+5mdzAdITBP9qvAjIgLQjjlRrH4\n"
+                        + "w8eXsXQXjJgyjR0CQHfvhiMPG5pWwmXpsEOFo6GKSvOC/5sNEcnddenuO/2T7WWi\n"
+                        + "o1LQh9naeuX8gti0vNR8+KtMEaIcJJeWnk56AVY=\n"
+                        + "-----END RSA PRIVATE KEY-----\n";
+            }
+
+            @CheckForNull
+            public Secret getPassphrase() {
+                return null;
+            }
+
+            @NonNull
+            public List<String> getPrivateKeys() {
+                return Collections.singletonList(getPrivateKey());
+            }
+        };
+    }
+
+    @Test
+    public void testAuthenticate() throws Exception {
+        SshServer sshd = SshServer.setUpDefaultServer();
+        sshd.setPort(0);
+        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
+        sshd.setPublickeyAuthenticator(new PublickeyAuthenticator() {
+            public boolean authenticate(String username, PublicKey key, ServerSession session) {
+                return username.equals("foobar");
+            }
+        });
+        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKey.Factory()));
+        try {
+            sshd.start();
+            connector = new JSchConnector(user.getUsername(), "localhost", sshd.getPort());
+            JSchSSHPublicKeyAuthenticator instance =
+                    new JSchSSHPublicKeyAuthenticator(connector, user);
+            assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.BEFORE_CONNECT));
+            assertThat(instance.canAuthenticate(), is(true));
+            assertThat(instance.authenticate(), is(true));
+            assertThat(instance.isAuthenticated(), is(true));
+            assertThat(connector.getSession().isConnected(), is(false));
+            connector.getSession().setConfig("StrictHostKeyChecking", "no");
+            connector.getSession().connect((int) TimeUnit.SECONDS.toMillis(30));
+            assertThat(connector.getSession().isConnected(), is(true));
+        } finally {
+            try {
+                sshd.stop(true);
+            } catch (Throwable t) {
+                Logger.getLogger(getClass().getName()).log(Level.WARNING, "Problems shutting down ssh server", t);
+            }
+        }
+    }
+
+    @Test
+    public void testFactory() throws Exception {
+        SshServer sshd = SshServer.setUpDefaultServer();
+        sshd.setPort(0);
+        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
+        sshd.setPublickeyAuthenticator(new PublickeyAuthenticator() {
+            public boolean authenticate(String username, PublicKey key, ServerSession session) {
+                return username.equals("foobar");
+            }
+        });
+        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKey.Factory()));
+        try {
+            sshd.start();
+            connector = new JSchConnector(user.getUsername(), "localhost", sshd.getPort());
+            SSHAuthenticator instance = SSHAuthenticator.newInstance(connector, user);
+            assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.BEFORE_CONNECT));
+            assertThat(instance.canAuthenticate(), is(true));
+            assertThat(instance.authenticate(), is(true));
+            assertThat(instance.isAuthenticated(), is(true));
+            assertThat(connector.getSession().isConnected(), is(false));
+            connector.getSession().setConfig("StrictHostKeyChecking", "no");
+            connector.getSession().connect((int) TimeUnit.SECONDS.toMillis(30));
+            assertThat(connector.getSession().isConnected(), is(true));
+        } finally {
+            try {
+                sshd.stop(true);
+            } catch (Throwable t) {
+                Logger.getLogger(getClass().getName()).log(Level.WARNING, "Problems shutting down ssh server", t);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR is a first step to release new version of the plugin.

**The context:**
The intent is to move built-in JSch implmentations from ssh-credentials-plugin to jsch-plugin, to isolate JSch as a dependency plugin and prevent ClassNotFoundException, triggered currently when depending on ssh-credentials-plugin
1st reference - https://github.com/jenkinsci/ssh-credentials-plugin/pull/19
2nd reference - https://github.com/jenkinsci/jsch-plugin/pull/1

**The release plan**
1. Merge this PD and release new vesion of jsch-plugin (0.1.54.0)
2. Rely on updated jsch-plugin and release ssh-plugin (probably major release 3.x)
3. Remove JSch specific stuff and release ssh-credentials-plugin (probably major 2.x release as advised by **stephenc**)
4. Update Confluence pages and JIRA tickets

**Purpose of this PR**
Why this PR and not #1 ? - this PR doesn't rely on unreleased 2.x version of ssh-credentials-plugin, so it didn't need coordinated release between plugins - it's easier to release plugin-by-plugin.
It's easier because  JSch auth classes has been moved to different package in jsch-plugin than in ssh-credentials-plugin, so they will be treated like separate JSch auth 'techniques'  - there is no need for coordinate release.
The duplication will be removed by Step3 of the plan above.
