### PR TITLE
General updates

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.0-beta-7</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,2 @@
 // Build the plugin using https://github.com/jenkins-infra/pipeline-library
-// TODO: cannot run tests against 2.89.3, it's SSHD Module is not binary compatible. Needs a bump to 2.60.x
-buildPlugin(jenkinsVersions: [null, '2.46.3'])
+buildPlugin(jenkinsVersions: [null, '2.138.4', '2.150.1'])

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.4</version>
+        <version>3.32</version>
     </parent>
 
     <artifactId>jsch</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     </parent>
 
     <artifactId>jsch</artifactId>
-    <version>0.1.54.3-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
 
     <name>Jenkins JSch dependency plugin</name>
@@ -21,7 +21,7 @@
         <connection>scm:git:git@github.com:jenkinsci/jsch-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/jsch-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/jsch-plugin/</url>
-        <tag>HEAD</tag>
+        <tag>${scmTag}</tag>
     </scm>
 
     <licenses>
@@ -55,6 +55,8 @@
     </developers>
 
     <properties>
+        <revision>0.1.54.3</revision>
+        <changelist>-SNAPSHOT</changelist>
         <jenkins.version>1.625.3</jenkins.version>
         <java.level>7</java.level>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
     <properties>
         <revision>0.1.55</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>1.625.3</jenkins.version>
-        <java.level>7</java.level>
+        <jenkins.version>2.60.3</jenkins.version>
+        <java.level>8</java.level>
     </properties>
 
   <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
@@ -89,6 +89,14 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-credentials</artifactId>
             <version>1.14</version>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.apache.sshd</groupId>
+            <artifactId>sshd-core</artifactId>
+            <version>2.1.0</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-credentials</artifactId>
-            <version>1.13</version>
+            <version>1.14</version>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     </developers>
 
     <properties>
-        <revision>0.1.54.3</revision>
+        <revision>0.1.55</revision>
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>1.625.3</jenkins.version>
         <java.level>7</java.level>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.54</version>
+            <version>0.1.55</version>
         </dependency>
 
         <!-- jenkins dependencies -->

--- a/src/test/java/org/jenkinsci/plugins/jsch/JSchSSHPasswordAuthenticatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/jsch/JSchSSHPasswordAuthenticatorTest.java
@@ -32,26 +32,22 @@ import com.jcraft.jsch.HostKeyRepository;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.UserInfo;
 import hudson.model.Items;
-import org.apache.sshd.SshServer;
-import org.apache.sshd.common.NamedFactory;
-import org.apache.sshd.server.PasswordAuthenticator;
-import org.apache.sshd.server.UserAuth;
-import org.apache.sshd.server.auth.UserAuthPassword;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.auth.password.UserAuthPasswordFactory;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
-import org.apache.sshd.server.session.ServerSession;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 public class JSchSSHPasswordAuthenticatorTest {
 
@@ -100,12 +96,8 @@ public class JSchSSHPasswordAuthenticatorTest {
         SshServer sshd = SshServer.setUpDefaultServer();
         sshd.setPort(0);
         sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
-        sshd.setPasswordAuthenticator(new PasswordAuthenticator() {
-            public boolean authenticate(String username, String password, ServerSession session) {
-                return "foomanchu".equals(password);
-            }
-        });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPassword.Factory()));
+        sshd.setPasswordAuthenticator((username, password, session) -> "foomanchu".equals(password));
+        sshd.setUserAuthFactories(Collections.singletonList(new UserAuthPasswordFactory()));
         try {
             sshd.start();
             connector = new JSchConnector(user.getUsername(),"localhost", sshd.getPort());
@@ -132,12 +124,8 @@ public class JSchSSHPasswordAuthenticatorTest {
         SshServer sshd = SshServer.setUpDefaultServer();
         sshd.setPort(0);
         sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
-        sshd.setPasswordAuthenticator(new PasswordAuthenticator() {
-            public boolean authenticate(String username, String password, ServerSession session) {
-                return "foomanchu".equals(password);
-            }
-        });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPassword.Factory()));
+        sshd.setPasswordAuthenticator((username, password, session) -> "foomanchu".equals(password));
+        sshd.setUserAuthFactories(Collections.singletonList(new UserAuthPasswordFactory()));
         try {
             sshd.start();
             connector = new JSchConnector(user.getUsername(),"localhost", sshd.getPort());

--- a/src/test/java/org/jenkinsci/plugins/jsch/JSchSSHPublicKeyAuthenticatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/jsch/JSchSSHPublicKeyAuthenticatorTest.java
@@ -106,21 +106,59 @@ public class JSchSSHPublicKeyAuthenticatorTest {
             public String getPrivateKey() {
                 // just want a valid key... I generated this and have thrown it away (other than here)
                 // do not use other than in this test
-                return "-----BEGIN RSA PRIVATE KEY-----\n"
-                        + "MIICWQIBAAKBgQDADDwooNPJNQB4N4bJPiBgq/rkWKMABApX0w4trSkkX5q+l+CL\n"
-                        + "CuddGGAsAu6XPari8v49ipbBmHqRLP9+X3ARGWKU2gDvGTBr99/ReUl2YgVjCwy+\n"
-                        + "KMrGCN7SNTgRo6StwVaPhh6pUpNTQciDe/kOwUnQFWSM6/lwkOD1Uod45wIBIwKB\n"
-                        + "gHi3O8HELVnmzRhdaqphkLHLL/0/B18Ye4epPBy1/JqFPLJQ1kjFBnUIAe/HVCSN\n"
-                        + "KZX30wIcmUZ9GdeYoJiTwsfTy9t2KwHjqrapTfiekVZAW+3iDBqRZMxQ5MoK7b6g\n"
-                        + "w5HrrtrtPfYuAsBnYjIS6qsKAVT3vdolJ5eai/RlPO4LAkEA76YuUozC/dW7Ox+R\n"
-                        + "1Njd6cWJsRVXGemkSYY/rSh0SbfHAebqL/bDg8xXim9UiuD9Hc6md3glHQj6iKvl\n"
-                        + "BxWq4QJBAM0moKiM16WFSFJP1wVDj0Bnx6DkJYSpf5u+C0ghBVoqIYKq6/P/gRE2\n"
-                        + "+ColsLu6AYftaEJVpAgxeTU/IsGoJMcCQHRmqMkCipiMYkFJ2R49cxnGWNJa0ojt\n"
-                        + "03QrQ3/9tNNZQ2dS5sbW8UAEKoURgNW9vMVVvpHMpE/uaw8u65W6ESsCQDTAyjn4\n"
-                        + "VLWIrDJsTTveLCaBFhNt3cMHA45ysnGiF1GzD+5mdzAdITBP9qvAjIgLQjjlRrH4\n"
-                        + "w8eXsXQXjJgyjR0CQHfvhiMPG5pWwmXpsEOFo6GKSvOC/5sNEcnddenuO/2T7WWi\n"
-                        + "o1LQh9naeuX8gti0vNR8+KtMEaIcJJeWnk56AVY=\n"
-                        + "-----END RSA PRIVATE KEY-----\n";
+                // this is a 4096-bit RSA key generated via:
+                // openssl genrsa 4096
+                return "-----BEGIN RSA PRIVATE KEY-----\n" +
+                        "MIIJKwIBAAKCAgEA4CmW6yE6HT8eTIsoN71tAn5EEfLqEDK2TzIT7wq8+lQB3CIx\n" +
+                        "9adUsgepILVUPc1miioTE1ujmVqjIqkeU6RJ6OuYH1+8AQXSUuq3fm3Zee023J7d\n" +
+                        "O52ktTCtTZmypqY72DNKBpfKYwat6CPtzcv2s8yRWqJXpuSIZaSgpkH/26XNOyj0\n" +
+                        "UCuOY5Z6t707sXuAtq1yg9SseCnbwbMuyUX8I9qH7d93LWmSGpzR6lrOlUg1ndg9\n" +
+                        "AlmBS2A0xdnIt6EVOa+2OipT7/6q69a2GG+GUtld59NXkEpQJksDYW8apwgty7nr\n" +
+                        "DSpc4AI52uOFoVIH+tYFvUPm2I78sg8v4vb5JkK5f3Kwb82EwWQZNWDvcRRoYDzv\n" +
+                        "U6CIaM6An6EjxyPjfkLaB/2qkoRTi5Zh7BVbEHLyc9lkxNZ32UnZeLNwOm6JVBdf\n" +
+                        "2AMOcgmVRAQFUfr9pnuE9Ndzx1PVeRd/myZ+fp1rxRF9W7sE9scvVsLh0Z9WcHa8\n" +
+                        "rRZulCKrtnHG6oQVP3pf7MrkjQXRY8CNm9oeWqmTxVi/oL1Ji0/Aty5BHerHtoCY\n" +
+                        "FN9mSR2cmY+ZMwGmtbv3is5xdUq1o4pco5a6vrtVDst4wQIuaRpz7/3YU26Rr16r\n" +
+                        "sPCqaARPGXKLHJ/COMydffccgvixRf9gUI+NVvs2Wh+2VwfQ3KkX4Fmdk+0CAwEA\n" +
+                        "AQKCAgEAxc4NXckBRiOXcgXt5FnkYqnXGVuYjdiiJXpUOsDoB6GvznfiTBpvU3YN\n" +
+                        "GU7JWovw6wS7tn5L/BwODpzbpQU5Ly8OGslY1jIz6XUznH4ExWG84qvRHzU5zaV5\n" +
+                        "mBuDmSjhcCO6M90n+4A+X7Wst8g/F2Px89+Dp0LM1ZyTIoLk6wcA9i5qgIAe8uQr\n" +
+                        "wA1dKn2IFCsz/P7jflm5kNCz/WojV+QTxKVHviwFgDRXzAx7dSG2JmZVV8hxnnjz\n" +
+                        "uI84Xknnt/LEw8jsLsA0RU4/e4qWJm+nPNWy1CGvXksdXZI0G6bM+pRBxWlXcVil\n" +
+                        "gvD4z2Tao87OW7gacYijleBu6kHzkdfLisuC8WyEfUWAtUAb2qHKQAf0HYvuiJ5O\n" +
+                        "OAORp6oxxtQzGHVcYLh68lrVE39dD80OKN7OltuPRp4lllUZtGzlBdPfBiRQiSPN\n" +
+                        "x6SmuSxGpqhJz96S2NT6ZVBBIuYuVXX6KhUdzB/45TzqBCXfwHJsv/DoRmcptKJx\n" +
+                        "kzSMTHZ9orLB9bthjMTsKmQUduPafqo1AspB0jxcKShias+D4DcymIbXpHEZ0TQZ\n" +
+                        "VjcPMzH4DTnoIaGkyVLg49hEb2ogH9RmM/Hsx7aZA00Aqn/BMDWhkMgHJRActKLC\n" +
+                        "SB0amuNCEu55+bHe5ejB+BhcMhlemtBxliqsfEy52JVwOBTX5sUCggEBAPI9p64n\n" +
+                        "J3tUTsuVWq46SgTJcpqY5GbNPg+f6qHtZgWyoAkAVRgYu7OXLFbcTtBA0axo0pm7\n" +
+                        "3kQCXDEAznHeGAENtodoVHzbvKTmBUJ0WbBqNiJFx8R4u3RB1K4BW5uDo5QTb/aQ\n" +
+                        "CDQ2yF5J60ltdskyfDUahkW2wPJEUnslyeViGgVrP21u0EhC18NpghWUQsN1RQdW\n" +
+                        "e+h0ds15armLMGxxf62ZI5GZl+RLwwjIczjxGm00C++yekasGWnkDikx50UGthyR\n" +
+                        "k4zG/a2ctt00hhgbHafQGwJj3VhTTPZvaqfdcHZYUH1B9S5ZsBHsiadON8w7z2mB\n" +
+                        "aAK/ktrUxe+C7AMCggEBAOzlEAxmfAyg7AUbN516DG1cZ5xX3vWc4s7jy6GsaD7d\n" +
+                        "5OEgZQQVZmi1xcjZaiF/BKOnzFDr/RlQJhNFsT4qotfk5Y79PMed/eoOg7DqdxAa\n" +
+                        "w1uzlqhrDHnlBXAXY5De7L3su4rBMg2O570L5FUbffPgym4aXaxg/etVUV7pQqPV\n" +
+                        "lcuyxBp93lG6MnHTJ4CZ7gTwb+XyFfhdF6P9WZOwpdoCjQg2eoYMZBo5h7LivziY\n" +
+                        "7N6hKgm5EQ2mrfJqHB3H540Dy4P03LEjk5xQDUnBn/gpj4ZePBFaiueEvlOXiCwP\n" +
+                        "+jXIfF+kAlef/UEBOJUHzzp39elqkU0msKLxghLzlU8CggEBAOrcBBrBM3JLRyny\n" +
+                        "4DxTnzgM5+QjoC5bh3Q2o5HjTSrxCGAxxk7ajAGO7Bo69t7KOX9jEeyjTNe7Qg7w\n" +
+                        "rTeREMzUsseNy3xSvw9RRIAttldoYpvP8+L0+ym4Oa+K+XpJousJ/V+cPZgCFTn1\n" +
+                        "iP1j9+sR24LQ+KXWjjNVMnLbLGgNORVP6er7qUymIfL/9HNfj2tZ41c97lxtrlGB\n" +
+                        "Coxh+szpLdTtyKJ9u9pH6gw17CClAe4mq/v1mr+yU+FqjqA6FfPCkgYYzmmK9KDC\n" +
+                        "dDj7l5b/kz0Ec2tZz1y3RsMXOt0NwN+8uCz5KfGKWz7FiqB/IXIN+wZbxLAFdShd\n" +
+                        "aprQ4GkCggEBAIOKokGwertsdAJV3aj1B4eGYwYeiPCrgAnP1dfdazlVb21O1qjQ\n" +
+                        "1T/Zh40CpPsak9HoL/zTPYRby/ixnzzc4fWt5YZjuedCJKdeDeQkHZ70rXvzGfpF\n" +
+                        "DvV0pXNbmW7tSlof5PekVY3Px4Bi5RQZIvRT4zQGMfOxG+4cPwXL0rQ0umwUxO3M\n" +
+                        "7LFHChHIZUv0rYVSmV/+8BIsZx8pZB8tXLrU5ckkrx5WLROe1GoRnIrp58WrijNB\n" +
+                        "72U8I6TTJO+ofDwCWnTYd99o2ONYVDibap+bPFYpZ4NfWng6bpDuOK/240IQJHfb\n" +
+                        "E23iqfb5nZircHeP+x30jeBgVn70Sf0KAuMCggEBAOG5wh1m5H981ZY1EPFxYpvH\n" +
+                        "mh2K0eoNUGlSmWcuq+L1k93xG5bsaKpZH2xSpRqcwARvAy+0kIncE14QAVsBuse9\n" +
+                        "B4G86IUlsKYe2aZt3Zo+2bz+CdHWZHYcNyj+aYrzRwB/z3d3F5sYccPL/Tmu34KQ\n" +
+                        "tU4Cglzfz8lGzpIwM7HN2JyubjO0Iy1UbEqP0RqK38LYP0SYPoinXVKXKAwEZ7gp\n" +
+                        "23bCUz4li9GjJ/Ke7ztcFES/9HzyUTw/L7VS6LHf99W0yjHpZ2OaqxrSXHGSXP0R\n" +
+                        "GNuyG1OI+KmyNhb332Bm3R8mSM3mw9wBrFM1VUmBtNwjn1P8qnyEwzo9tdZNxoI=\n" +
+                        "-----END RSA PRIVATE KEY-----";
             }
 
             @CheckForNull

--- a/src/test/java/org/jenkinsci/plugins/jsch/JSchSSHPublicKeyAuthenticatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/jsch/JSchSSHPublicKeyAuthenticatorTest.java
@@ -25,12 +25,8 @@ package org.jenkinsci.plugins.jsch;
 
 import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator;
 import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
-import com.cloudbees.plugins.credentials.CredentialsDescriptor;
+import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
 import com.cloudbees.plugins.credentials.CredentialsScope;
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.util.Secret;
-import org.apache.sshd.common.keyprovider.KeyPairProvider;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.auth.pubkey.UserAuthPublicKeyFactory;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
@@ -40,8 +36,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import java.security.Key;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -51,7 +52,8 @@ import static org.junit.Assert.assertThat;
 
 public class JSchSSHPublicKeyAuthenticatorTest {
 
-    private final KeyPairProvider keyPairProvider = new SimpleGeneratorHostKeyProvider();
+    private KeyPair keyPair;
+
     private JSchConnector connector;
     private SSHUserPrivateKey user;
 
@@ -67,114 +69,20 @@ public class JSchSSHPublicKeyAuthenticatorTest {
 
     @Before
     public void setUp() throws Exception {
-        user = new SSHUserPrivateKey() {
-
-            @NonNull
-            public String getUsername() {
-                return "foobar";
-            }
-
-            @NonNull
-            public String getDescription() {
-                return "";
-            }
-
-            @NonNull
-            public String getId() {
-                return "";
-            }
-
-            public CredentialsScope getScope() {
-                return CredentialsScope.SYSTEM;
-            }
-
-            @NonNull
-            public CredentialsDescriptor getDescriptor() {
-                return new CredentialsDescriptor() {
-                    @Override
-                    public String getDisplayName() {
-                        return "";
-                    }
-                };
-            }
-
-            @NonNull
-            public String getPrivateKey() {
-                // just want a valid key... I generated this and have thrown it away (other than here)
-                // do not use other than in this test
-                // this is a 4096-bit RSA key generated via:
-                // openssl genrsa 4096
-                return "-----BEGIN RSA PRIVATE KEY-----\n" +
-                        "MIIJKwIBAAKCAgEA4CmW6yE6HT8eTIsoN71tAn5EEfLqEDK2TzIT7wq8+lQB3CIx\n" +
-                        "9adUsgepILVUPc1miioTE1ujmVqjIqkeU6RJ6OuYH1+8AQXSUuq3fm3Zee023J7d\n" +
-                        "O52ktTCtTZmypqY72DNKBpfKYwat6CPtzcv2s8yRWqJXpuSIZaSgpkH/26XNOyj0\n" +
-                        "UCuOY5Z6t707sXuAtq1yg9SseCnbwbMuyUX8I9qH7d93LWmSGpzR6lrOlUg1ndg9\n" +
-                        "AlmBS2A0xdnIt6EVOa+2OipT7/6q69a2GG+GUtld59NXkEpQJksDYW8apwgty7nr\n" +
-                        "DSpc4AI52uOFoVIH+tYFvUPm2I78sg8v4vb5JkK5f3Kwb82EwWQZNWDvcRRoYDzv\n" +
-                        "U6CIaM6An6EjxyPjfkLaB/2qkoRTi5Zh7BVbEHLyc9lkxNZ32UnZeLNwOm6JVBdf\n" +
-                        "2AMOcgmVRAQFUfr9pnuE9Ndzx1PVeRd/myZ+fp1rxRF9W7sE9scvVsLh0Z9WcHa8\n" +
-                        "rRZulCKrtnHG6oQVP3pf7MrkjQXRY8CNm9oeWqmTxVi/oL1Ji0/Aty5BHerHtoCY\n" +
-                        "FN9mSR2cmY+ZMwGmtbv3is5xdUq1o4pco5a6vrtVDst4wQIuaRpz7/3YU26Rr16r\n" +
-                        "sPCqaARPGXKLHJ/COMydffccgvixRf9gUI+NVvs2Wh+2VwfQ3KkX4Fmdk+0CAwEA\n" +
-                        "AQKCAgEAxc4NXckBRiOXcgXt5FnkYqnXGVuYjdiiJXpUOsDoB6GvznfiTBpvU3YN\n" +
-                        "GU7JWovw6wS7tn5L/BwODpzbpQU5Ly8OGslY1jIz6XUznH4ExWG84qvRHzU5zaV5\n" +
-                        "mBuDmSjhcCO6M90n+4A+X7Wst8g/F2Px89+Dp0LM1ZyTIoLk6wcA9i5qgIAe8uQr\n" +
-                        "wA1dKn2IFCsz/P7jflm5kNCz/WojV+QTxKVHviwFgDRXzAx7dSG2JmZVV8hxnnjz\n" +
-                        "uI84Xknnt/LEw8jsLsA0RU4/e4qWJm+nPNWy1CGvXksdXZI0G6bM+pRBxWlXcVil\n" +
-                        "gvD4z2Tao87OW7gacYijleBu6kHzkdfLisuC8WyEfUWAtUAb2qHKQAf0HYvuiJ5O\n" +
-                        "OAORp6oxxtQzGHVcYLh68lrVE39dD80OKN7OltuPRp4lllUZtGzlBdPfBiRQiSPN\n" +
-                        "x6SmuSxGpqhJz96S2NT6ZVBBIuYuVXX6KhUdzB/45TzqBCXfwHJsv/DoRmcptKJx\n" +
-                        "kzSMTHZ9orLB9bthjMTsKmQUduPafqo1AspB0jxcKShias+D4DcymIbXpHEZ0TQZ\n" +
-                        "VjcPMzH4DTnoIaGkyVLg49hEb2ogH9RmM/Hsx7aZA00Aqn/BMDWhkMgHJRActKLC\n" +
-                        "SB0amuNCEu55+bHe5ejB+BhcMhlemtBxliqsfEy52JVwOBTX5sUCggEBAPI9p64n\n" +
-                        "J3tUTsuVWq46SgTJcpqY5GbNPg+f6qHtZgWyoAkAVRgYu7OXLFbcTtBA0axo0pm7\n" +
-                        "3kQCXDEAznHeGAENtodoVHzbvKTmBUJ0WbBqNiJFx8R4u3RB1K4BW5uDo5QTb/aQ\n" +
-                        "CDQ2yF5J60ltdskyfDUahkW2wPJEUnslyeViGgVrP21u0EhC18NpghWUQsN1RQdW\n" +
-                        "e+h0ds15armLMGxxf62ZI5GZl+RLwwjIczjxGm00C++yekasGWnkDikx50UGthyR\n" +
-                        "k4zG/a2ctt00hhgbHafQGwJj3VhTTPZvaqfdcHZYUH1B9S5ZsBHsiadON8w7z2mB\n" +
-                        "aAK/ktrUxe+C7AMCggEBAOzlEAxmfAyg7AUbN516DG1cZ5xX3vWc4s7jy6GsaD7d\n" +
-                        "5OEgZQQVZmi1xcjZaiF/BKOnzFDr/RlQJhNFsT4qotfk5Y79PMed/eoOg7DqdxAa\n" +
-                        "w1uzlqhrDHnlBXAXY5De7L3su4rBMg2O570L5FUbffPgym4aXaxg/etVUV7pQqPV\n" +
-                        "lcuyxBp93lG6MnHTJ4CZ7gTwb+XyFfhdF6P9WZOwpdoCjQg2eoYMZBo5h7LivziY\n" +
-                        "7N6hKgm5EQ2mrfJqHB3H540Dy4P03LEjk5xQDUnBn/gpj4ZePBFaiueEvlOXiCwP\n" +
-                        "+jXIfF+kAlef/UEBOJUHzzp39elqkU0msKLxghLzlU8CggEBAOrcBBrBM3JLRyny\n" +
-                        "4DxTnzgM5+QjoC5bh3Q2o5HjTSrxCGAxxk7ajAGO7Bo69t7KOX9jEeyjTNe7Qg7w\n" +
-                        "rTeREMzUsseNy3xSvw9RRIAttldoYpvP8+L0+ym4Oa+K+XpJousJ/V+cPZgCFTn1\n" +
-                        "iP1j9+sR24LQ+KXWjjNVMnLbLGgNORVP6er7qUymIfL/9HNfj2tZ41c97lxtrlGB\n" +
-                        "Coxh+szpLdTtyKJ9u9pH6gw17CClAe4mq/v1mr+yU+FqjqA6FfPCkgYYzmmK9KDC\n" +
-                        "dDj7l5b/kz0Ec2tZz1y3RsMXOt0NwN+8uCz5KfGKWz7FiqB/IXIN+wZbxLAFdShd\n" +
-                        "aprQ4GkCggEBAIOKokGwertsdAJV3aj1B4eGYwYeiPCrgAnP1dfdazlVb21O1qjQ\n" +
-                        "1T/Zh40CpPsak9HoL/zTPYRby/ixnzzc4fWt5YZjuedCJKdeDeQkHZ70rXvzGfpF\n" +
-                        "DvV0pXNbmW7tSlof5PekVY3Px4Bi5RQZIvRT4zQGMfOxG+4cPwXL0rQ0umwUxO3M\n" +
-                        "7LFHChHIZUv0rYVSmV/+8BIsZx8pZB8tXLrU5ckkrx5WLROe1GoRnIrp58WrijNB\n" +
-                        "72U8I6TTJO+ofDwCWnTYd99o2ONYVDibap+bPFYpZ4NfWng6bpDuOK/240IQJHfb\n" +
-                        "E23iqfb5nZircHeP+x30jeBgVn70Sf0KAuMCggEBAOG5wh1m5H981ZY1EPFxYpvH\n" +
-                        "mh2K0eoNUGlSmWcuq+L1k93xG5bsaKpZH2xSpRqcwARvAy+0kIncE14QAVsBuse9\n" +
-                        "B4G86IUlsKYe2aZt3Zo+2bz+CdHWZHYcNyj+aYrzRwB/z3d3F5sYccPL/Tmu34KQ\n" +
-                        "tU4Cglzfz8lGzpIwM7HN2JyubjO0Iy1UbEqP0RqK38LYP0SYPoinXVKXKAwEZ7gp\n" +
-                        "23bCUz4li9GjJ/Ke7ztcFES/9HzyUTw/L7VS6LHf99W0yjHpZ2OaqxrSXHGSXP0R\n" +
-                        "GNuyG1OI+KmyNhb332Bm3R8mSM3mw9wBrFM1VUmBtNwjn1P8qnyEwzo9tdZNxoI=\n" +
-                        "-----END RSA PRIVATE KEY-----";
-            }
-
-            @CheckForNull
-            public Secret getPassphrase() {
-                return null;
-            }
-
-            @NonNull
-            public List<String> getPrivateKeys() {
-                return Collections.singletonList(getPrivateKey());
-            }
-        };
+        KeyPairGenerator rsaGenerator = KeyPairGenerator.getInstance("RSA");
+        rsaGenerator.initialize(4096);
+        keyPair = rsaGenerator.genKeyPair();
+        BasicSSHUserPrivateKey.PrivateKeySource privateKeySource =
+                new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(encodeKeyToPemForm(keyPair.getPrivate()));
+        user = new BasicSSHUserPrivateKey(CredentialsScope.SYSTEM, "foobar", "foobar", privateKeySource, null, null);
     }
 
     @Test
     public void testAuthenticate() throws Exception {
         SshServer sshd = SshServer.setUpDefaultServer();
         sshd.setPort(0);
-        sshd.setKeyPairProvider(keyPairProvider);
-        sshd.setPublickeyAuthenticator((username, key, session) -> username.equals("foobar"));
+        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
+        sshd.setPublickeyAuthenticator((username, key, session) -> username.equals("foobar") && Arrays.equals(key.getEncoded(), keyPair.getPublic().getEncoded()));
         sshd.setUserAuthFactories(Collections.singletonList(new UserAuthPublicKeyFactory()));
         try {
             sshd.start();
@@ -202,8 +110,8 @@ public class JSchSSHPublicKeyAuthenticatorTest {
     public void testFactory() throws Exception {
         SshServer sshd = SshServer.setUpDefaultServer();
         sshd.setPort(0);
-        sshd.setKeyPairProvider(keyPairProvider);
-        sshd.setPublickeyAuthenticator((username, key, session) -> username.equals("foobar"));
+        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
+        sshd.setPublickeyAuthenticator((username, key, session) -> username.equals("foobar") && Arrays.equals(key.getEncoded(), keyPair.getPublic().getEncoded()));
         sshd.setUserAuthFactories(Collections.singletonList(new UserAuthPublicKeyFactory()));
         try {
             sshd.start();
@@ -224,5 +132,15 @@ public class JSchSSHPublicKeyAuthenticatorTest {
                 Logger.getLogger(getClass().getName()).log(Level.WARNING, "Problems shutting down ssh server", t);
             }
         }
+    }
+
+    private static String encodeKeyToPemForm(Key key) {
+        return "-----BEGIN " +
+                (key instanceof PrivateKey ? "PRIVATE" : "PUBLIC") +
+                " KEY-----\n" +
+                Base64.getEncoder().encodeToString(key.getEncoded()) +
+                "\n-----END " +
+                (key instanceof PrivateKey ? "PRIVATE" : "PUBLIC") +
+                " KEY-----\n";
     }
 }


### PR DESCRIPTION
This PR brings a few modernizations to this plugin:

* Latest plugin parent pom.
* Incrementals support.
* Latest release of JSch (non-security release).
* Latest version of Apache SSHD for testing.
* Updated to require Jenkins 2.60.3 and Java 8.
* Replaced hard-coded RSA key in unit test with randomly generated one at runtime.

This supersedes #5.

Changes since version 0.1.54:
- bugfix: fixed vulnerabilities in examples;
          ScpTo.java, ScpFrom.java and ScpNoneCipher.java,
          https://gist.github.com/ymnk/2318108/revisions#diff-a5ec82fe8ccb2efa64aa42a5592bb137
          https://gist.github.com/ymnk/2318108/revisions#diff-c1b069ab3a670f4fd3270d0f57550007
          https://gist.github.com/ymnk/2318108/revisions#diff-a20032aa3cc9119fa627ec948b9ada46
          thanks to Dylan Katz(http://dylankatz.com).
- bugfix: OpenSSHConfig#getUser() should not overwrite the given user-name.
- bugfix: fixed 'Invalid encoding for signature' errors in ssh-dss.
- bugfix: fixed bugs in the key-exchange for ecdsa-sha2-nistp384,
          ecdsa-sha2-nistp521.
- bugfix: failed to generate the key pair from private keys,
          ecdsa 384 and 521.
- bugfix: failed to load the ecdsa 521 key identity from ssh-add command.
- change: updating copyright messages; 2016 -> 2018
- feature: supporting key files on EBCDIC environment.

@jeffret-b @dwnusbaum @reviewbybees