### PR TITLE
[WEBSITE-637] Use GitHub as the source of documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+## Version 0.1.55.1 (July 29, 2019)
+
+-   Minor POM updates for clarity and consistency
+-   No functionality changes
+
+## Version 0.1.55 (Jan 9, 2019)
+
+-   Update JSch dependency to 0.1.55
+-   Update dependencies
+
+## Version 0.1.54.2 (Feb 16, 2018)
+
+-   [JENKINS-49584](https://issues.jenkins-ci.org/browse/JENKINS-49584) -
+    Prevent warning from Plugin Manager when dynamically loading the
+    plugin
+-   Update minimum Jenkins core requirement to 1.625.3
+
+## Version 0.1.54.1 (Nov 24, 2016)
+
+-   Update JSch dependency to 0.1.54
+-   Support for SSH Credentials
+
+## Version 0.1.42 (Oct 5, 2016)
+
+-   Initial release with JSch version 0.1.42

--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
-jsch-plugin
-===========
 
-Jenkins plugin that brings the JSch library as a plugin dependency
+# JSch Jenkins Plugin
+[![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/jsch.svg?color=blue)](https://plugins.jenkins.io/jsch)
+[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/jsch.svg?color=blue)](https://plugins.jenkins.io/jsch)
+
+
+This plugin provides a shared dependency on the `com.jcraft:jsch` JAR -
+using this plugin will eliminate the classloader problems caused by
+having multiple copies of jsch loaded.**This plugin is not meant to be
+used by end users by itself.**
+
+It's supposed to be included through the dependencies of other plugins,
+which want to use JSch library with support for SSH Credentials plugin.
+
+## Version History
+Please refer to [the changelog](CHANGELOG.md).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <packaging>hpi</packaging>
 
     <name>Jenkins JSch dependency plugin</name>
-    <url>https://wiki.jenkins.io/display/JENKINS/JSch+plugin</url>
+    <url>https://github.com/jenkinsci/jsch-plugin</url>
     <description>
         Jenkins plugin that brings the JSch library as a plugin dependency, and provides
         an SSHAuthenticatorFactory for using JSch with the ssh-credentials plugin.


### PR DESCRIPTION
See [WEBSITE-637](https://issues.jenkins-ci.org/browse/WEBSITE-637)