### PR TITLE
Add trilead-api and bump jenkins core

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,2 @@
 // Build the plugin using https://github.com/jenkins-infra/pipeline-library
-buildPlugin(jenkinsVersions: [null, '2.138.4', '2.150.1'])
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.48</version>
+        <version>4.0-beta-4</version>
         <relativePath />
     </parent>
 
@@ -58,7 +58,7 @@
     <properties>
         <revision>0.1.55.2</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.190.1</jenkins.version>
         <java.level>8</java.level>
     </properties>
 
@@ -83,6 +83,11 @@
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
             <version>0.1.55</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>trilead-api</artifactId>
+            <version>1.0.5</version>
         </dependency>
 
         <!-- jenkins dependencies -->


### PR DESCRIPTION
Same change was required in ssh-credentials and other plugins after trilead-api split:
https://github.com/jenkinsci/ssh-credentials-plugin/commit/68ce416ec00b88a13579285df5cacaea8f39d435#diff-600376dffeb79835ede4a0b285078036