### PR TITLE
[JENKINS-69150] Update to mwiede/jsch 0.2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     </developers>
 
     <properties>
-        <revision>0.1.55</revision>
+        <revision>0.2.4</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <jenkins.version>2.319.1</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
@@ -86,7 +86,7 @@
     <dependencies>
         <!-- plugin dependencies -->
         <dependency>
-            <groupId>com.jcraft</groupId>
+            <groupId>com.github.mwiede</groupId>
             <artifactId>jsch</artifactId>
             <version>${revision}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     </developers>
 
     <properties>
-        <revision>0.2.4</revision>
+        <revision>0.2.8</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <jenkins.version>2.319.1</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,7 @@
     </parent>
 
     <artifactId>jsch</artifactId>
-    <!-- TODO: Switch separator from '.' to '-' next time jsch dependency is updated. -->
-    <version>${revision}.${changelist}</version>
+    <version>${revision}-${changelist}</version>
     <packaging>hpi</packaging>
 
     <name>Jenkins JSch dependency plugin</name>


### PR DESCRIPTION
see [JENKINS-69150](https://issues.jenkins.io/browse/JENKINS-69150)

[mwiede/jsch](https://github.com/mwiede/jsch) is a fork of Jsch with:
- a public repo
- a tracker
- a community, apparently
- support for more modern ssh implementations, provided a recent enough java is used. See https://github.com/mwiede/jsch/blob/master/ChangeLog.md

Also worth considering whether this closes [JENKINS-56031](https://issues.jenkins.io/browse/JENKINS-56031)

According to the fork, this should be a drop-in replacement. Not adding new tests.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
