### PR TITLE
Modernization for JDK21 and JDK21 tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 // Build the plugin using https://github.com/jenkins-infra/pipeline-library
 buildPlugin(useContainerAgent: true, configurations: [
-        [platform: 'linux', jdk: '21'],
+        [platform: 'linux', jdk: 21],
         [platform: 'linux', jdk: '11'],
         [platform: 'linux', jdk: '17', jenkins: '2.342'],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 // Build the plugin using https://github.com/jenkins-infra/pipeline-library
 buildPlugin(useContainerAgent: true, configurations: [
         [platform: 'linux', jdk: 21],
-        [platform: 'linux', jdk: '11'],
-        [platform: 'linux', jdk: '17', jenkins: '2.342'],
+        [platform: 'linux', jdk: 11],
+        [platform: 'linux', jdk: 17],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 // Build the plugin using https://github.com/jenkins-infra/pipeline-library
 buildPlugin(useContainerAgent: true, configurations: [
-        [platform: 'linux', jdk: '8'],
+        [platform: 'linux', jdk: '21'],
         [platform: 'linux', jdk: '11'],
         [platform: 'linux', jdk: '17', jenkins: '2.342'],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,5 @@
 buildPlugin(useContainerAgent: true, configurations: [
         [platform: 'linux', jdk: 21],
         [platform: 'linux', jdk: 11],
-        [platform: 'linux', jdk: 17],
+        [platform: 'windows', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.73</version>
+        <version>4.74</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.44</version>
+        <version>4.73</version>
         <relativePath />
     </parent>
 
@@ -51,7 +51,7 @@
     <properties>
         <revision>0.2.8</revision>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.319.1</jenkins.version>
+        <jenkins.version>2.361.4</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
 
@@ -74,8 +74,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.319.x</artifactId>
-                <version>1508.v4b_d09ff0e893</version>
+                <artifactId>bom-2.361.x</artifactId>
+                <version>1763.v092b_8980a_f5e</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.74</version>
+        <version>4.76</version>
         <relativePath />
     </parent>
 
@@ -75,7 +75,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.361.x</artifactId>
-                <version>1763.v092b_8980a_f5e</version>
+                <version>2102.v854b_fec19c92</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Test with Java 21
==

Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 in early October and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only two Java configurations, Java 17 and Java 21 because we believe that the risk of a regression that only affects Java 11 is shallow. We generate Java 11 byte code with the Java 17 and the Java 21 builds, so we're already testing Java 11 byte code.

Testing done
===

I had to update the parent POM to get it to work with JDK21.
As soon as I did that, I had to change the Jenkins version, or it wouldn't compile.
Then I also changed the BOM version to be the same as the Jenkins version (as described in the "[Improve a plugin tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/update-base-jenkins-version/#update-minimum-required-jenkins-version)").

Confirmed tests pass with Java 21.