### PR TITLE
Remove unused trilead-api dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,10 +89,6 @@
             <artifactId>jsch</artifactId>
             <version>${revision}</version>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>trilead-api</artifactId>
-        </dependency>
 
         <!-- jenkins dependencies -->
         <dependency>


### PR DESCRIPTION
This removes the (unused?) dependency to the trilead-api plugin.

I'm probably missing some classloader(?) subtlety here, please feel free to
close if this is invalid...

This dependency was added by @timja in #11, so it serves... some purpose?

Since we don't use that dependency in this plugin and already get it through
`ssh-credentials`, this seems to be redundant...

### Testing done

Unit tests and `mvn hpi:run` "testing" only.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
